### PR TITLE
Recognize new RPi 3 B+ Rev. v1.3

### DIFF
--- a/src/ethoscope/web_utils/helpers.py
+++ b/src/ethoscope/web_utils/helpers.py
@@ -46,6 +46,9 @@ def pi_version():
     elif hardware.group(1) == 'BCM2835' and '1041' in revision.group(1):
         # Pi 3
         return 3
+    elif hardware.group(1) == 'BCM2835' and 'a020d3' in revision.group(1):
+        # Pi 3
+        return 3
     else:
         # Something else, not a pi.
         return 0


### PR DESCRIPTION
Add new revision of RPi 3 B+ Rev. v1.3

```
Hardware	: BCM2835
Revision	        : a020d3
Serial		: 000000005d377ac6
Model		: Raspberry Pi 3 Model B Plus Rev 1.3
```